### PR TITLE
Fixes task execution and error handling

### DIFF
--- a/internal/outofband/action_handlers.go
+++ b/internal/outofband/action_handlers.go
@@ -223,9 +223,9 @@ func (h *actionHandler) downloadFirmware(a sw.StateSwitch, c sw.TransitionArgs) 
 
 	// validate checksum
 	//
-	// This assumes the checksum is of type SHA256
+	// This assumes the checksum is of type MD5
 	// it would be ideal if the firmware object indicated the type of checksum.
-	if err := checksumValidateSHA256(file, action.Firmware.Checksum); err != nil {
+	if err := checksumValidateMD5(file, action.Firmware.Checksum); err != nil {
 		os.RemoveAll(filepath.Dir(file))
 		return err
 	}

--- a/internal/outofband/action_handlers.go
+++ b/internal/outofband/action_handlers.go
@@ -50,7 +50,7 @@ var (
 	ErrActionTypeAssertion     = errors.New("error occurred in action object type assertion")
 	ErrContextCancelled        = errors.New("context canceled")
 	ErrUnexpected              = errors.New("unexpected error occurred")
-	ErrInstalledFirmwareEqual  = errors.New("installed firmware equal")
+	ErrInstalledFirmwareEqual  = errors.New("installed and expected firmware equal")
 	ErrInstalledVersionUnknown = errors.New("installed version unknown")
 	ErrComponentNotFound       = errors.New("component not found for firmware install")
 )
@@ -192,9 +192,9 @@ func (h *actionHandler) checkCurrentFirmware(a sw.StateSwitch, c sw.TransitionAr
 				"component":        action.Firmware.Component,
 				"vendor":           action.Firmware.Vendor,
 				"models":           action.Firmware.Models,
-				"plannedVersion":   action.Firmware.Version,
+				"expectedVersion":  action.Firmware.Version,
 				"installedVersion": component.FirmwareInstalled,
-			}).Error("Installed firmware version equals planned - set TaskParameters.Force=true to disable this check")
+			}).Error("Installed firmware version equals expected - set TaskParameters.Force=true to disable this check")
 
 		return ErrInstalledFirmwareEqual
 	}

--- a/internal/outofband/action_handlers.go
+++ b/internal/outofband/action_handlers.go
@@ -194,7 +194,6 @@ func (h *actionHandler) checkCurrentFirmware(a sw.StateSwitch, c sw.TransitionAr
 				"models":           action.Firmware.Models,
 				"plannedVersion":   action.Firmware.Version,
 				"installedVersion": component.FirmwareInstalled,
-				"err":              err.Error(),
 			}).Error("Installed firmware version equals planned - set TaskParameters.Force=true to disable this check")
 
 		return ErrInstalledFirmwareEqual

--- a/internal/outofband/actions_test.go
+++ b/internal/outofband/actions_test.go
@@ -106,13 +106,13 @@ func Test_ActionStateMachine_Run_Succeeds(t *testing.T) {
 
 	// firmware blob served
 	blob := []byte(`blob`)
-	blobChecksum := "fa2c8cc4f28176bbeed4b736df569a34c79cd3723e9ec42f9674b4d46ac6b8b8"
+	blobMD5Checksum := "ee26908bf9629eeb4b37dac350f4754a"
 
 	server := httptest.NewServer(serverMux(t, blob))
 
 	// rig firmware endpoints to point to the test service
 	firmware[0].URL = server.URL + "/dummy.bin"
-	firmware[0].Checksum = blobChecksum
+	firmware[0].Checksum = blobMD5Checksum
 	firmware[0].FileName = "dummy.bin"
 
 	action := model.Action{
@@ -167,7 +167,7 @@ func Test_ActionStateMachine_Run_Fails(t *testing.T) {
 
 	// firmware blob served
 	blob := []byte(`blob`)
-	blobChecksum := "fa2c8cc4f28176bbeed4b736df569a34c79cd3723e9ec42f9674b4d46ac6b8b8"
+	blobChecksum := "ee26908bf9629eeb4b37dac350f4754a"
 
 	server := httptest.NewServer(serverMux(t, blob))
 

--- a/internal/outofband/download.go
+++ b/internal/outofband/download.go
@@ -3,7 +3,7 @@ package outofband
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
+	"crypto/md5"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,7 +63,9 @@ func download(ctx context.Context, fileURL, dst string) error {
 	return err
 }
 
-func checksumValidateSHA256(filename, checksum string) error {
+// TODO: firmware-syncer needs to prefix firmware checksums values with the type of checksum
+// so consumers can validate it accordingly
+func checksumValidateMD5(filename, checksum string) error {
 	var err error
 
 	expectedChecksum := []byte(checksum)
@@ -79,7 +81,7 @@ func checksumValidateSHA256(filename, checksum string) error {
 	}
 	defer f.Close()
 
-	h := sha256.New()
+	h := md5.New()
 
 	// TODO(joel) - wrap this within a context
 	if _, err := io.Copy(h, f); err != nil {

--- a/internal/statemachine/task.go
+++ b/internal/statemachine/task.go
@@ -307,7 +307,11 @@ func (m *TaskStateMachine) Run(task *model.Task, tctx *HandlerContext) error {
 			if errors.Is(err, sw.NoConditionPassedToRunTransaction) {
 				err = errors.Wrap(
 					ErrTaskTransition,
-					fmt.Sprintf("no transition rule found for task transition type '%s' and state '%s'", transitionType, task.Status),
+					fmt.Sprintf(
+						"no transition rule found for task transition type '%s' in state '%s'",
+						transitionType,
+						task.State(),
+					),
 				)
 			}
 

--- a/internal/worker/task_handler.go
+++ b/internal/worker/task_handler.go
@@ -123,6 +123,9 @@ func (h *taskHandler) Run(t sw.StateSwitch, args sw.TransitionArgs) error {
 
 		// fetch action attributes from task
 		action := task.ActionsPlanned.ByID(actionSM.ActionID())
+		if err := action.SetState(model.StateActive); err != nil {
+			return err
+		}
 
 		// run the action state machine
 		err := actionSM.Run(tctx.Ctx, action, tctx)


### PR DESCRIPTION
#### What does this PR do
- Fixes the issue where Actions would not be executed because the state field was incorrect.
- Switches the checksum to md5 for verifying downloaded firmware files - to reflect the data in serverservice.
- Return consistent errors on action failures.
