### PR TITLE
ci/release: quote Go version so its not interpret as 1.2 vs 1.20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
       -
         name: install cosign
         uses: sigstore/cosign-installer@main
@@ -44,4 +44,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1
-          GOVERSION: 1.20
+          GOVERSION: "1.20"


### PR DESCRIPTION
#### What does this PR do

Attempts to resolve https://github.com/metal-toolbox/flasher/actions/runs/5123999398/jobs/9229608359