### PR TITLE
Misc fixes

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"log"
-	"net/http"
 	"strings"
 
 	"github.com/metal-toolbox/flasher/internal/app"
@@ -39,11 +38,6 @@ var (
 )
 
 func runWorker(ctx context.Context) {
-	go func() {
-		// nolint:gosec // timeouts aren't a real concern when dealing with this endpoint.
-		log.Println(http.ListenAndServe("localhost:9091", nil))
-	}()
-
 	flasher, termCh, err := app.New(
 		model.AppKindWorker,
 		model.StoreKind(storeKind),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/metal-toolbox/flasher/internal/app"
+	"github.com/metal-toolbox/flasher/internal/metrics"
 	"github.com/metal-toolbox/flasher/internal/model"
 	"github.com/metal-toolbox/flasher/internal/store"
 	"github.com/metal-toolbox/flasher/internal/worker"
@@ -48,6 +49,9 @@ func runWorker(ctx context.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// serve metrics endpoint
+	metrics.ListenAndServe()
 
 	// Setup cancel context with cancel func.
 	ctx, cancelFunc := context.WithCancel(ctx)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -90,7 +90,7 @@ func New(appKind model.AppKind, storeKind model.StoreKind, cfgFile, loglevel str
 func enableProfilingEndpoint() {
 	go func() {
 		server := &http.Server{
-			Addr:              "",
+			Addr:              ProfilingEndpoint,
 			ReadHeaderTimeout: 2 * time.Second, // nolint:gomnd // time duration value is clear as is.
 		}
 

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -184,6 +184,14 @@ func (a *App) envVarNatsOverrides() error {
 		return errors.New("missing parameter: nats.url")
 	}
 
+	if a.v.GetString("nats.publisherSubjectPrefix") != "" {
+		a.Config.NatsOptions.PublisherSubjectPrefix = a.v.GetString("nats.publisherSubjectPrefix")
+	}
+
+	if a.Config.NatsOptions.PublisherSubjectPrefix == "" {
+		return errors.New("missing parameter: nats.publisherSubjectPrefix")
+	}
+
 	if a.v.GetString("nats.stream.user") != "" {
 		a.Config.NatsOptions.StreamUser = a.v.GetString("nats.stream.user")
 	}
@@ -214,6 +222,22 @@ func (a *App) envVarNatsOverrides() error {
 		}
 
 		a.Config.NatsOptions.Consumer.Name = a.v.GetString("nats.consumer.name")
+	}
+
+	if len(a.v.GetStringSlice("nats.consumer.subscribeSubjects")) != 0 {
+		a.Config.NatsOptions.Consumer.SubscribeSubjects = a.v.GetStringSlice("nats.consumer.subscribeSubjects")
+	}
+
+	if len(a.Config.NatsOptions.Consumer.SubscribeSubjects) == 0 {
+		return errors.New("missing parameter: nats.consumer.subscribeSubjects")
+	}
+
+	if a.v.GetString("nats.consumer.filterSubject") != "" {
+		a.Config.NatsOptions.Consumer.FilterSubject = a.v.GetString("nats.consumer.filterSubject")
+	}
+
+	if a.Config.NatsOptions.Consumer.FilterSubject == "" {
+		return errors.New("missing parameter: nats.consumer.filterSubject")
 	}
 
 	if a.Config.NatsOptions.ConnectTimeout == 0 {

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -240,6 +240,10 @@ func (a *App) envVarNatsOverrides() error {
 		return errors.New("missing parameter: nats.consumer.filterSubject")
 	}
 
+	if a.v.GetDuration("nats.connect.timeout") != 0 {
+		a.Config.NatsOptions.ConnectTimeout = a.v.GetDuration("nats.connect.timeout")
+	}
+
 	if a.Config.NatsOptions.ConnectTimeout == 0 {
 		a.Config.NatsOptions.ConnectTimeout = defaultNatsConnectTimeout
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,29 @@
+package metrics
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	MetricsEndpoint = "0.0.0.0:9090"
+)
+
+// ListenAndServeMetrics exposes prometheus metrics as /metrics
+func ListenAndServe() {
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+
+		server := &http.Server{
+			Addr:              MetricsEndpoint,
+			ReadHeaderTimeout: 2 * time.Second, // nolint:gomnd // time duration value is clear as is.
+		}
+
+		if err := server.ListenAndServe(); err != nil {
+			log.Println(err)
+		}
+	}()
+}


### PR DESCRIPTION
#### What does this PR do

Adds various fixes to enable flasher to run in a k8s environment.

- Load required NATS stream parameters from env vars.
- Clean up pprof endpoint, purge duplicated functions.
- Serve prom metrics on port 9090