### PR TITLE
add a KV status publisher for Flasher

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,8 @@ run:
 #  build-tags:
   skip-dirs:
     - internal/fixtures
+  skip-files:
+    - "(.*/)*.*_test.go"
 
 issues:
   exclude-rules:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,7 +29,7 @@ var cmdRun = &cobra.Command{
 
 // run worker command
 var (
-	useKV          bool
+	useStatusKV    bool
 	dryrun         bool
 	faultInjection bool
 	storeKind      string
@@ -77,7 +77,7 @@ func runWorker(ctx context.Context) {
 	w := worker.New(
 		flasher.Config.FacilityCode,
 		dryrun,
-		useKV,
+		useStatusKV,
 		faultInjection,
 		flasher.Config.Concurrency,
 		stream,
@@ -103,7 +103,7 @@ func initInventory(ctx context.Context, config *app.Configuration, logger *logru
 func init() {
 	cmdRun.PersistentFlags().StringVar(&storeKind, "store", "", "inventory store to lookup devices for update - 'serverservice' or an inventory file with a .yml/.yaml extenstion")
 	cmdRun.PersistentFlags().BoolVarP(&dryrun, "dry-run", "", false, "In dryrun mode, the worker actions the task without installing firmware")
-	cmdRun.PersistentFlags().BoolVarP(&useKV, "use-kv", "", false, "when this is true, flasher writes status to a NATS KV store instead of sending reply messages")
+	cmdRun.PersistentFlags().BoolVarP(&useStatusKV, "use-kv", "", false, "when this is true, flasher writes status to a NATS KV store instead of sending reply messages")
 	cmdRun.PersistentFlags().BoolVarP(&faultInjection, "fault-injection", "", false, "Tasks can include a Fault attribute to allow fault injection for development purposes")
 
 	if err := cmdRun.MarkPersistentFlagRequired("store"); err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,6 +29,7 @@ var cmdRun = &cobra.Command{
 
 // run worker command
 var (
+	useKV          bool
 	dryrun         bool
 	faultInjection bool
 	storeKind      string
@@ -76,6 +77,7 @@ func runWorker(ctx context.Context) {
 	w := worker.New(
 		flasher.Config.FacilityCode,
 		dryrun,
+		useKV,
 		faultInjection,
 		flasher.Config.Concurrency,
 		stream,
@@ -101,6 +103,7 @@ func initInventory(ctx context.Context, config *app.Configuration, logger *logru
 func init() {
 	cmdRun.PersistentFlags().StringVar(&storeKind, "store", "", "inventory store to lookup devices for update - 'serverservice' or an inventory file with a .yml/.yaml extenstion")
 	cmdRun.PersistentFlags().BoolVarP(&dryrun, "dry-run", "", false, "In dryrun mode, the worker actions the task without installing firmware")
+	cmdRun.PersistentFlags().BoolVarP(&useKV, "use-kv", "", false, "when this is true, flasher writes status to a NATS KV store instead of sending reply messages")
 	cmdRun.PersistentFlags().BoolVarP(&faultInjection, "fault-injection", "", false, "Tasks can include a Fault attribute to allow fault injection for development purposes")
 
 	if err := cmdRun.MarkPersistentFlagRequired("store"); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/metal-toolbox/conditionorc v0.0.0-20230525152515-9f519f51f7e8
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/nats-io/nats-server/v2 v2.9.15
 	github.com/nats-io/nats.go v1.25.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.15.1
@@ -75,6 +76,7 @@ require (
 	github.com/jacobweinstock/iamt v0.0.0-20230304043040-a6b4a1001123 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.16.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/lib/pq v1.10.9 // indirect
@@ -82,6 +84,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/minio/highwayhash v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nats-io/jwt/v2 v2.4.0 // indirect
@@ -124,6 +127,7 @@ require (
 	golang.org/x/exp v0.0.0-20230519143937-03e91628a987 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/api v0.119.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1419,6 +1419,7 @@ github.com/klauspost/compress v1.13.4/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
+github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
@@ -1581,6 +1582,7 @@ github.com/nats-io/jwt/v2 v2.4.0 h1:1woVcq37qhNwJOeZ4ZoRy5NJU5bvbtGsIammf2GpuJQ=
 github.com/nats-io/jwt/v2 v2.4.0/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
 github.com/nats-io/nats-server/v2 v2.5.0/go.mod h1:Kj86UtrXAL6LwYRA6H4RqzkHhK0Vcv2ZnKD5WbQ1t3g=
 github.com/nats-io/nats-server/v2 v2.9.15 h1:MuwEJheIwpvFgqvbs20W8Ish2azcygjf4Z0liVu2I4c=
+github.com/nats-io/nats-server/v2 v2.9.15/go.mod h1:QlCTy115fqpx4KSOPFIxSV7DdI6OxtZsGOL1JLdeRlE=
 github.com/nats-io/nats.go v1.12.1/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.25.0 h1:t5/wCPGciR7X3Mu8QOi4jiJaXaWM8qtkLu4lzGZvYHE=
 github.com/nats-io/nats.go v1.25.0/go.mod h1:D2WALIhz7V8M0pH8Scx8JZXlg6Oqz5VG+nQkK8nJdvg=

--- a/internal/outofband/action_handlers.go
+++ b/internal/outofband/action_handlers.go
@@ -535,7 +535,7 @@ func (h *actionHandler) PublishStatus(_ sw.StateSwitch, args sw.TransitionArgs) 
 		return sm.ErrInvalidTransitionHandler
 	}
 
-	tctx.Publisher.Publish(tctx, tctx.Task)
+	tctx.Publisher.Publish(tctx)
 
 	return nil
 }

--- a/internal/outofband/actions_test.go
+++ b/internal/outofband/actions_test.go
@@ -28,7 +28,7 @@ func newTaskFixture(status string) *model.Task {
 // eventEmitter implements the statemachine.Publisher interface
 type eventEmitter struct{}
 
-func (e *eventEmitter) Publish(_ *sm.HandlerContext, _ *model.Task) {}
+func (e *eventEmitter) Publish(_ *sm.HandlerContext) {}
 
 func newtaskHandlerContextFixture(task *model.Task, asset *model.Asset) *sm.HandlerContext {
 	repository, _ := store.NewMockInventory()

--- a/internal/statemachine/actions.go
+++ b/internal/statemachine/actions.go
@@ -156,7 +156,7 @@ func (a *ActionStateMachine) Run(ctx context.Context, action *model.Action, tctx
 			string(transitionType),
 		)
 
-		tctx.Publisher.Publish(tctx, tctx.Task)
+		tctx.Publisher.Publish(tctx)
 
 		// return on context cancellation
 		if ctx.Err() != nil {
@@ -202,7 +202,7 @@ func (a *ActionStateMachine) Run(ctx context.Context, action *model.Action, tctx
 			string(transitionType),
 		)
 
-		tctx.Publisher.Publish(tctx, tctx.Task)
+		tctx.Publisher.Publish(tctx)
 	}
 
 	// run transition success handler

--- a/internal/statemachine/task.go
+++ b/internal/statemachine/task.go
@@ -10,6 +10,7 @@ import (
 	"github.com/metal-toolbox/flasher/internal/store"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"go.hollow.sh/toolbox/events/registry"
 )
 
 const (
@@ -34,7 +35,7 @@ var (
 
 // Publisher defines methods to publish task information.
 type Publisher interface {
-	Publish(ctx *HandlerContext, task *model.Task)
+	Publish(ctx *HandlerContext)
 }
 
 // HandlerContext holds references to objects required to complete firmware install task and action transitions.
@@ -74,7 +75,7 @@ type HandlerContext struct {
 	Logger *logrus.Entry
 
 	// WorkerID is the identifier for the worker executing this task.
-	WorkerID string
+	WorkerID registry.ControllerID
 
 	// ActionStateMachines are sub-statemachines of this Task
 	// each firmware applicable has a Action statemachine that is
@@ -87,6 +88,9 @@ type HandlerContext struct {
 	//
 	// It is upto the Action handler implementations to ensure the dry run works as described.
 	Dryrun bool
+
+	// LastRev is the last revision of the status data for this task stored in NATS KV
+	LastRev uint64
 }
 
 // TaskTransitioner defines stateswitch methods that handle state transitions.

--- a/internal/worker/kv_status.go
+++ b/internal/worker/kv_status.go
@@ -41,14 +41,14 @@ func (s *statusKVPublisher) Publish(hCtx *sm.HandlerContext) {
 		rev, err = s.kv.Update(key, payload, hCtx.LastRev)
 	}
 
-	if err == nil {
-		hCtx.LastRev = rev
-	} else {
+	if err != nil {
 		s.log.WithError(err).WithFields(logrus.Fields{
 			"task_id":  hCtx.Task.ID.String(),
 			"last_rev": hCtx.LastRev,
 		}).Warn("unable to write task status")
+		return
 	}
+	hCtx.LastRev = rev
 }
 
 type statusValue struct {

--- a/internal/worker/kv_status.go
+++ b/internal/worker/kv_status.go
@@ -1,0 +1,103 @@
+//nolint:gomnd //useless opinions
+package worker
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	sm "github.com/metal-toolbox/flasher/internal/statemachine"
+	"github.com/nats-io/nats.go"
+	"github.com/sirupsen/logrus"
+
+	"go.hollow.sh/toolbox/events"
+	"go.hollow.sh/toolbox/events/pkg/kv"
+)
+
+var (
+	statusKVName  = "flasher-status"
+	defaultKVOpts = []kv.Option{
+		kv.WithReplicas(3),
+		kv.WithDescription("flasher condition status tracking"),
+		kv.WithTTL(10 * 24 * time.Hour),
+	}
+)
+
+type statusKVPublisher struct {
+	kv  nats.KeyValue
+	log *logrus.Logger
+}
+
+// Publish implements the statemachine Publisher interface.
+func (s *statusKVPublisher) Publish(hCtx *sm.HandlerContext) {
+	key := fmt.Sprintf("%s/%s", hCtx.Asset.FacilityCode, hCtx.Task.ID.String())
+	payload := statusFromContext(hCtx)
+
+	var err error
+	var rev uint64
+	if hCtx.LastRev == 0 {
+		rev, err = s.kv.Create(key, payload)
+	} else {
+		rev, err = s.kv.Update(key, payload, hCtx.LastRev)
+	}
+
+	if err == nil {
+		hCtx.LastRev = rev
+	} else {
+		s.log.WithError(err).WithFields(logrus.Fields{
+			"task_id":  hCtx.Task.ID.String(),
+			"last_rev": hCtx.LastRev,
+		}).Warn("unable to write task status")
+	}
+}
+
+type statusValue struct {
+	UpdatedAt time.Time       `json:"updated"`
+	WorkerID  string          `json:"worker"`
+	Target    string          `json:"target"`
+	State     string          `json:"state"`
+	Status    json.RawMessage `json:"status"`
+	// WorkSpec json.RawMessage `json:"spec"`
+}
+
+// panic if we cannot serialize to JSON
+func (v *statusValue) MustBytes() []byte {
+	byt, err := json.Marshal(v)
+	if err != nil {
+		panic("unable to serialize status value: " + err.Error())
+	}
+	return byt
+}
+
+func statusFromContext(hCtx *sm.HandlerContext) []byte {
+	sv := &statusValue{
+		WorkerID:  hCtx.WorkerID.String(),
+		Target:    hCtx.Asset.ID.String(),
+		State:     string(hCtx.Task.State()),
+		Status:    statusInfoJSON(hCtx.Task.Status),
+		UpdatedAt: time.Now(),
+	}
+	return sv.MustBytes()
+}
+
+func NewStatusKVPublisher(s events.Stream, log *logrus.Logger, opts ...kv.Option) sm.Publisher {
+	js, ok := s.(*events.NatsJetstream)
+	if !ok {
+		log.Fatal("status-kv publisher is only supported on NATS")
+	}
+
+	kvOpts := defaultKVOpts
+	if len(opts) > 0 {
+		kvOpts = opts
+	}
+
+	statusKV, err := kv.CreateOrBindKVBucket(js, statusKVName, kvOpts...)
+	if err != nil {
+		log.WithError(err).Fatal("unable to bind status KV bucket")
+	}
+
+	return &statusKVPublisher{
+		kv:  statusKV,
+		log: log,
+	}
+}

--- a/internal/worker/kv_status_test.go
+++ b/internal/worker/kv_status_test.go
@@ -1,0 +1,106 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/metal-toolbox/flasher/internal/model"
+	sm "github.com/metal-toolbox/flasher/internal/statemachine"
+	"github.com/nats-io/nats-server/v2/server"
+	srvtest "github.com/nats-io/nats-server/v2/test"
+	"github.com/nats-io/nats.go"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.hollow.sh/toolbox/events"
+	"go.hollow.sh/toolbox/events/pkg/kv"
+	"go.hollow.sh/toolbox/events/registry"
+)
+
+func startJetStreamServer(t *testing.T) *server.Server {
+	t.Helper()
+	opts := srvtest.DefaultTestOptions
+	opts.Port = -1
+	opts.JetStream = true
+	return srvtest.RunServer(&opts)
+}
+
+func jetStreamContext(t *testing.T, s *server.Server) (*nats.Conn, nats.JetStreamContext) {
+	t.Helper()
+	nc, err := nats.Connect(s.ClientURL())
+	if err != nil {
+		t.Fatalf("connect => %v", err)
+	}
+	js, err := nc.JetStream(nats.MaxWait(10 * time.Second))
+	if err != nil {
+		t.Fatalf("JetStream => %v", err)
+	}
+	return nc, js
+}
+
+func shutdownJetStream(t *testing.T, s *server.Server) {
+	t.Helper()
+	var sd string
+	if config := s.JetStreamConfig(); config != nil {
+		sd = config.StoreDir
+	}
+	s.Shutdown()
+	if sd != "" {
+		if err := os.RemoveAll(sd); err != nil {
+			t.Fatalf("Unable to remove storage %q: %v", sd, err)
+		}
+	}
+	s.WaitForShutdown()
+}
+
+func TestPublisher(t *testing.T) {
+	srv := startJetStreamServer(t)
+	defer shutdownJetStream(t, srv)
+	nc, js := jetStreamContext(t, srv) // nc is closed on evJS.Close(), js needs no cleanup
+	evJS := events.NewJetstreamFromConn(nc)
+	defer evJS.Close()
+
+	pub := NewStatusKVPublisher(evJS, logrus.New(), kv.WithReplicas(1))
+	require.NotNil(t, pub, "publisher constructor")
+
+	readHandle, err := js.KeyValue("flasher-status")
+	require.NoError(t, err, "read handle")
+
+	taskID := uuid.New()
+	assetID := uuid.New()
+
+	testContext := &sm.HandlerContext{
+		Ctx: context.TODO(),
+		Task: &model.Task{
+			ID:     taskID,
+			Status: "some-status",
+		},
+		WorkerID: registry.GetID("kvtest"),
+		Asset: &model.Asset{
+			ID:           assetID,
+			FacilityCode: "fac13",
+		},
+	}
+	testContext.Task.SetState(model.StatePending)
+	require.NotPanics(t, func() { pub.Publish(testContext) }, "publish initial")
+	require.NotEqual(t, 0, testContext.LastRev, "last rev - 1")
+
+	entry, err := readHandle.Get("fac13/" + taskID.String())
+	require.Equal(t, entry.Revision(), testContext.LastRev, "last rev - 2")
+
+	sv := &statusValue{}
+	err = json.Unmarshal(entry.Value(), sv)
+	require.NoError(t, err, "unmarshal")
+
+	require.Equal(t, assetID.String(), sv.Target, "sv Target")
+	require.Equal(t, json.RawMessage(`{"msg":"some-status"}`), sv.Status, "sv Status")
+
+	testContext.Task.SetState(model.StateActive)
+	require.NotPanics(t, func() { pub.Publish(testContext) }, "publish revision")
+
+	entry, err = readHandle.Get("fac13/" + taskID.String())
+	require.Equal(t, entry.Revision(), testContext.LastRev, "last rev - 3")
+}

--- a/internal/worker/task_handler.go
+++ b/internal/worker/task_handler.go
@@ -170,18 +170,13 @@ func (h *taskHandler) TaskSuccessful(_ sw.StateSwitch, args sw.TransitionArgs) e
 	return nil
 }
 
-func (h *taskHandler) PublishStatus(t sw.StateSwitch, args sw.TransitionArgs) error {
+func (h *taskHandler) PublishStatus(_ sw.StateSwitch, args sw.TransitionArgs) error {
 	tctx, ok := args.(*sm.HandlerContext)
 	if !ok {
 		return sm.ErrInvalidTransitionHandler
 	}
 
-	task, ok := t.(*model.Task)
-	if !ok {
-		return errors.Wrap(ErrSaveTask, ErrTaskTypeAssertion.Error())
-	}
-
-	tctx.Publisher.Publish(tctx, task)
+	tctx.Publisher.Publish(tctx)
 
 	return nil
 }
@@ -218,14 +213,14 @@ func (h *taskHandler) queryFromDevice(tctx *sm.HandlerContext) (model.Components
 	}
 
 	tctx.Task.Status = "connecting to device BMC"
-	tctx.Publisher.Publish(tctx, tctx.Task)
+	tctx.Publisher.Publish(tctx)
 
 	if err := tctx.DeviceQueryor.Open(tctx.Ctx); err != nil {
 		return nil, err
 	}
 
 	tctx.Task.Status = "collecting inventory from device BMC"
-	tctx.Publisher.Publish(tctx, tctx.Task)
+	tctx.Publisher.Publish(tctx)
 
 	deviceCommon, err := tctx.DeviceQueryor.Inventory(tctx.Ctx)
 	if err != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -54,14 +54,14 @@ type Worker struct {
 	dispatched     int32
 	dryrun         bool
 	faultInjection bool
-	useKV          bool
+	useStatusKV    bool
 }
 
 // NewOutofbandWorker returns a out of band firmware install worker instance
 func New(
 	facilityCode string,
 	dryrun,
-	useKV,
+	useStatusKV,
 	faultInjection bool,
 	concurrency int,
 	stream events.Stream,
@@ -74,7 +74,7 @@ func New(
 		name:           fmt.Sprintf("flasher-%s", id),
 		facilityCode:   facilityCode,
 		dryrun:         dryrun,
-		useKV:          useKV,
+		useStatusKV:    useStatusKV,
 		faultInjection: faultInjection,
 		concurrency:    concurrency,
 		syncWG:         &sync.WaitGroup{},
@@ -304,7 +304,7 @@ func (o *Worker) runTaskWithMonitor(ctx context.Context, task *model.Task, asset
 }
 
 func (o *Worker) getStatusPublisher() sm.Publisher {
-	if o.useKV {
+	if o.useStatusKV {
 		return NewStatusKVPublisher(o.stream, o.logger)
 	}
 	return &statusEmitter{o.stream, o.logger}


### PR DESCRIPTION
#### What does this PR do
Provides a configurable NATS KV interface for status updates. The default behavior of the app is unchanged, but setting `use-kv` to `true` on the command line (like `dry-run`) instructs Flasher to use the new KV functionality.