### PR TITLE
Vc/export install status obj

### DIFF
--- a/internal/worker/kv_status.go
+++ b/internal/worker/kv_status.go
@@ -2,11 +2,11 @@
 package worker
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
 	sm "github.com/metal-toolbox/flasher/internal/statemachine"
+	"github.com/metal-toolbox/flasher/types"
 	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
 
@@ -51,26 +51,8 @@ func (s *statusKVPublisher) Publish(hCtx *sm.HandlerContext) {
 	hCtx.LastRev = rev
 }
 
-type statusValue struct {
-	UpdatedAt time.Time       `json:"updated"`
-	WorkerID  string          `json:"worker"`
-	Target    string          `json:"target"`
-	State     string          `json:"state"`
-	Status    json.RawMessage `json:"status"`
-	// WorkSpec json.RawMessage `json:"spec"`
-}
-
-// panic if we cannot serialize to JSON
-func (v *statusValue) MustBytes() []byte {
-	byt, err := json.Marshal(v)
-	if err != nil {
-		panic("unable to serialize status value: " + err.Error())
-	}
-	return byt
-}
-
 func statusFromContext(hCtx *sm.HandlerContext) []byte {
-	sv := &statusValue{
+	sv := &types.StatusValue{
 		WorkerID:  hCtx.WorkerID.String(),
 		Target:    hCtx.Asset.ID.String(),
 		State:     string(hCtx.Task.State()),

--- a/internal/worker/kv_status.go
+++ b/internal/worker/kv_status.go
@@ -30,7 +30,7 @@ type statusKVPublisher struct {
 
 // Publish implements the statemachine Publisher interface.
 func (s *statusKVPublisher) Publish(hCtx *sm.HandlerContext) {
-	key := fmt.Sprintf("%s/%s", hCtx.Asset.FacilityCode, hCtx.Task.ID.String())
+	key := fmt.Sprintf("%s.%s", hCtx.Asset.FacilityCode, hCtx.Task.ID.String())
 	payload := statusFromContext(hCtx)
 
 	var err error

--- a/internal/worker/kv_status_test.go
+++ b/internal/worker/kv_status_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/metal-toolbox/flasher/internal/model"
 	sm "github.com/metal-toolbox/flasher/internal/statemachine"
+	"github.com/metal-toolbox/flasher/types"
 	"github.com/nats-io/nats-server/v2/server"
 	srvtest "github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
@@ -91,10 +92,11 @@ func TestPublisher(t *testing.T) {
 	entry, err := readHandle.Get("fac13/" + taskID.String())
 	require.Equal(t, entry.Revision(), testContext.LastRev, "last rev - 2")
 
-	sv := &statusValue{}
+	sv := &types.StatusValue{}
 	err = json.Unmarshal(entry.Value(), sv)
 	require.NoError(t, err, "unmarshal")
 
+	require.Equal(t, types.Version, sv.Version, "version check")
 	require.Equal(t, assetID.String(), sv.Target, "sv Target")
 	require.Equal(t, json.RawMessage(`{"msg":"some-status"}`), sv.Status, "sv Status")
 

--- a/internal/worker/kv_status_test.go
+++ b/internal/worker/kv_status_test.go
@@ -89,7 +89,7 @@ func TestPublisher(t *testing.T) {
 	require.NotPanics(t, func() { pub.Publish(testContext) }, "publish initial")
 	require.NotEqual(t, 0, testContext.LastRev, "last rev - 1")
 
-	entry, err := readHandle.Get("fac13/" + taskID.String())
+	entry, err := readHandle.Get("fac13." + taskID.String())
 	require.Equal(t, entry.Revision(), testContext.LastRev, "last rev - 2")
 
 	sv := &types.StatusValue{}
@@ -103,6 +103,6 @@ func TestPublisher(t *testing.T) {
 	testContext.Task.SetState(model.StateActive)
 	require.NotPanics(t, func() { pub.Publish(testContext) }, "publish revision")
 
-	entry, err = readHandle.Get("fac13/" + taskID.String())
+	entry, err = readHandle.Get("fac13." + taskID.String())
 	require.Equal(t, entry.Revision(), testContext.LastRev, "last rev - 3")
 }

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	Version int32 = 1
+)
+
+// StatusValue is the canonical structure
+type StatusValue struct {
+	UpdatedAt time.Time       `json:"updated"`
+	Version   int32           `json:"version"`
+	WorkerID  string          `json:"worker"`
+	Target    string          `json:"target"`
+	State     string          `json:"state"`
+	Status    json.RawMessage `json:"status"`
+	// WorkSpec json.RawMessage `json:"spec"` XXX: for re-publish use-cases
+}
+
+// MustBytes sets the version field of the StatusValue so any callers don't have
+// to deal with it. It will panic if we cannot serialize to JSON for some reason.
+func (v *StatusValue) MustBytes() []byte {
+	v.Version = Version
+	byt, err := json.Marshal(v)
+	if err != nil {
+		panic("unable to serialize status value: " + err.Error())
+	}
+	return byt
+}

--- a/types/types.go
+++ b/types/types.go
@@ -12,11 +12,11 @@ const (
 // StatusValue is the canonical structure
 type StatusValue struct {
 	UpdatedAt time.Time       `json:"updated"`
-	Version   int32           `json:"version"`
 	WorkerID  string          `json:"worker"`
 	Target    string          `json:"target"`
 	State     string          `json:"state"`
 	Status    json.RawMessage `json:"status"`
+	Version   int32           `json:"version"`
 	// WorkSpec json.RawMessage `json:"spec"` XXX: for re-publish use-cases
 }
 


### PR DESCRIPTION
#### What does this PR do
Exports the Flasher status object so that ConditionOrc (and potentially other consumers) can use it deserializing NATS messages from Flasher.
