### PR TITLE
name the status KV identically to ConditionOrc

### DIFF
--- a/internal/worker/kv_status.go
+++ b/internal/worker/kv_status.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	cotyp "github.com/metal-toolbox/conditionorc/pkg/types"
 	sm "github.com/metal-toolbox/flasher/internal/statemachine"
 	"github.com/metal-toolbox/flasher/types"
 	"github.com/nats-io/nats.go"
@@ -15,7 +16,7 @@ import (
 )
 
 var (
-	statusKVName  = "flasher-status"
+	statusKVName  = string(cotyp.FirmwareInstall)
 	defaultKVOpts = []kv.Option{
 		kv.WithReplicas(3),
 		kv.WithDescription("flasher condition status tracking"),
@@ -53,10 +54,12 @@ func (s *statusKVPublisher) Publish(hCtx *sm.HandlerContext) {
 
 func statusFromContext(hCtx *sm.HandlerContext) []byte {
 	sv := &types.StatusValue{
-		WorkerID:  hCtx.WorkerID.String(),
-		Target:    hCtx.Asset.ID.String(),
-		State:     string(hCtx.Task.State()),
-		Status:    statusInfoJSON(hCtx.Task.Status),
+		WorkerID: hCtx.WorkerID.String(),
+		Target:   hCtx.Asset.ID.String(),
+		State:    string(hCtx.Task.State()),
+		Status:   statusInfoJSON(hCtx.Task.Status),
+		// ResourceVersion:  XXX: the handler context has no concept of this! does this make
+		// sense at the controller-level?
 		UpdatedAt: time.Now(),
 	}
 	return sv.MustBytes()

--- a/internal/worker/kv_status_test.go
+++ b/internal/worker/kv_status_test.go
@@ -67,7 +67,7 @@ func TestPublisher(t *testing.T) {
 	pub := NewStatusKVPublisher(evJS, logrus.New(), kv.WithReplicas(1))
 	require.NotNil(t, pub, "publisher constructor")
 
-	readHandle, err := js.KeyValue("flasher-status")
+	readHandle, err := js.KeyValue("firmwareInstall")
 	require.NoError(t, err, "read handle")
 
 	taskID := uuid.New()
@@ -96,7 +96,7 @@ func TestPublisher(t *testing.T) {
 	err = json.Unmarshal(entry.Value(), sv)
 	require.NoError(t, err, "unmarshal")
 
-	require.Equal(t, types.Version, sv.Version, "version check")
+	require.Equal(t, types.Version, sv.MsgVersion, "version check")
 	require.Equal(t, assetID.String(), sv.Target, "sv Target")
 	require.Equal(t, json.RawMessage(`{"msg":"some-status"}`), sv.Status, "sv Status")
 

--- a/types/types.go
+++ b/types/types.go
@@ -9,21 +9,22 @@ const (
 	Version int32 = 1
 )
 
-// StatusValue is the canonical structure
+// StatusValue is the canonical structure for reporting status of an ongoing firmware install
 type StatusValue struct {
-	UpdatedAt time.Time       `json:"updated"`
-	WorkerID  string          `json:"worker"`
-	Target    string          `json:"target"`
-	State     string          `json:"state"`
-	Status    json.RawMessage `json:"status"`
-	Version   int32           `json:"version"`
+	UpdatedAt       time.Time       `json:"updated"`
+	WorkerID        string          `json:"worker"`
+	Target          string          `json:"target"`
+	State           string          `json:"state"`
+	Status          json.RawMessage `json:"status"`
+	ResourceVersion int64           `json:"resourceVersion"` // for updates to server-service
+	MsgVersion      int32           `json:"msgVersion"`
 	// WorkSpec json.RawMessage `json:"spec"` XXX: for re-publish use-cases
 }
 
 // MustBytes sets the version field of the StatusValue so any callers don't have
 // to deal with it. It will panic if we cannot serialize to JSON for some reason.
 func (v *StatusValue) MustBytes() []byte {
-	v.Version = Version
+	v.MsgVersion = Version
 	byt, err := json.Marshal(v)
 	if err != nil {
 		panic("unable to serialize status value: " + err.Error())


### PR DESCRIPTION
#### What does this PR do

Update the name of the NATS KV bucket we use for firmware-install status. Also revise the exported status structure a bit to account for locking and lock-management in Serverservice.