### PR TITLE
allow for runtime override of KV replica count

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,6 +33,7 @@ var (
 	dryrun         bool
 	faultInjection bool
 	storeKind      string
+	replicas       int
 )
 
 var (
@@ -80,6 +81,7 @@ func runWorker(ctx context.Context) {
 		useStatusKV,
 		faultInjection,
 		flasher.Config.Concurrency,
+		replicas,
 		stream,
 		inv,
 		flasher.Logger,
@@ -105,6 +107,7 @@ func init() {
 	cmdRun.PersistentFlags().BoolVarP(&dryrun, "dry-run", "", false, "In dryrun mode, the worker actions the task without installing firmware")
 	cmdRun.PersistentFlags().BoolVarP(&useStatusKV, "use-kv", "", false, "when this is true, flasher writes status to a NATS KV store instead of sending reply messages")
 	cmdRun.PersistentFlags().BoolVarP(&faultInjection, "fault-injection", "", false, "Tasks can include a Fault attribute to allow fault injection for development purposes")
+	cmdRun.PersistentFlags().IntVarP(&replicas, "nats-replicas", "r", 1, "the default number of replicas to use for NATS data")
 
 	if err := cmdRun.MarkPersistentFlagRequired("store"); err != nil {
 		log.Fatal(err)

--- a/internal/worker/kv_status.go
+++ b/internal/worker/kv_status.go
@@ -18,7 +18,6 @@ import (
 var (
 	statusKVName  = string(cotyp.FirmwareInstall)
 	defaultKVOpts = []kv.Option{
-		kv.WithReplicas(3),
 		kv.WithDescription("flasher condition status tracking"),
 		kv.WithTTL(10 * 24 * time.Hour),
 	}
@@ -78,9 +77,7 @@ func NewStatusKVPublisher(s events.Stream, log *logrus.Logger, opts ...kv.Option
 	}
 
 	kvOpts := defaultKVOpts
-	if len(opts) > 0 {
-		kvOpts = opts
-	}
+	kvOpts = append(kvOpts, opts...)
 
 	statusKV, err := kv.CreateOrBindKVBucket(js, statusKVName, kvOpts...)
 	if err != nil {


### PR DESCRIPTION
#### What does this PR do
Define a run-time configuration flag to specify the number of replicas to share the KV data. This defaults to 1, but will be updated in the production helm-chart to override it.
