### PR TITLE
Firmware install ordering and delay  added

### DIFF
--- a/internal/worker/task_handler.go
+++ b/internal/worker/task_handler.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/bmc-toolbox/common"
@@ -271,6 +273,8 @@ func (h *taskHandler) planInstall(_ *sm.HandlerContext, task *model.Task, firmwa
 	// final is set to true in the final action
 	var final bool
 
+	sortFirmwareByInstallOrder(firmwares)
+
 	// each firmware applicable results in an ActionPlan and an Action
 	for idx, firmware := range firmwares {
 		// set final bool when its the last firmware in the slice
@@ -324,4 +328,12 @@ func (h *taskHandler) planInstall(_ *sm.HandlerContext, task *model.Task, firmwa
 	}
 
 	return actionMachines, actions, nil
+}
+
+func sortFirmwareByInstallOrder(firmwares []*model.Firmware) {
+	sort.Slice(firmwares, func(i, j int) bool {
+		slugi := strings.ToLower(firmwares[i].Component)
+		slugj := strings.ToLower(firmwares[j].Component)
+		return model.FirmwareInstallOrder[slugi] < model.FirmwareInstallOrder[slugj]
+	})
 }

--- a/internal/worker/task_handler_test.go
+++ b/internal/worker/task_handler_test.go
@@ -1,0 +1,68 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/metal-toolbox/flasher/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_sortFirmwareByInstallOrde(t *testing.T) {
+	have := []*model.Firmware{
+		{
+			Version:   "DL6R",
+			URL:       "https://downloads.dell.com/FOLDER06303849M/1/Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
+			FileName:  "Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "4189d3cb123a781d09a4f568bb686b23c6d8e6b82038eba8222b91c380a25281",
+			Component: "drive",
+		},
+		{
+			Version:   "2.6.6",
+			URL:       "https://dl.dell.com/FOLDER08105057M/1/BIOS_C4FT0_WN64_2.6.6.EXE",
+			FileName:  "BIOS_C4FT0_WN64_2.6.6.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "1ddcb3c3d0fc5925ef03a3dde768e9e245c579039dd958fc0f3a9c6368b6c5f4",
+			Component: "bios",
+		},
+		{
+			Version:   "20.5.13",
+			URL:       "https://dl.dell.com/FOLDER08105057M/1/Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
+			FileName:  "Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "b445417d7869bdbdffe7bad69ce32dc19fa29adc61f8e82a324545cabb53f30a",
+			Component: "nic",
+		},
+	}
+
+	expected := []*model.Firmware{
+		{
+			Version:   "2.6.6",
+			URL:       "https://dl.dell.com/FOLDER08105057M/1/BIOS_C4FT0_WN64_2.6.6.EXE",
+			FileName:  "BIOS_C4FT0_WN64_2.6.6.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "1ddcb3c3d0fc5925ef03a3dde768e9e245c579039dd958fc0f3a9c6368b6c5f4",
+			Component: "bios",
+		},
+		{
+			Version:   "DL6R",
+			URL:       "https://downloads.dell.com/FOLDER06303849M/1/Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
+			FileName:  "Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "4189d3cb123a781d09a4f568bb686b23c6d8e6b82038eba8222b91c380a25281",
+			Component: "drive",
+		},
+		{
+			Version:   "20.5.13",
+			URL:       "https://dl.dell.com/FOLDER08105057M/1/Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
+			FileName:  "Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "b445417d7869bdbdffe7bad69ce32dc19fa29adc61f8e82a324545cabb53f30a",
+			Component: "nic",
+		},
+	}
+
+	sortFirmwareByInstallOrder(have)
+
+	assert.Equal(t, expected, have)
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -495,14 +493,6 @@ func newTaskFromCondition(condition *cptypes.Condition, faultInjection bool) (*m
 	}
 
 	return &task, nil
-}
-
-func sortFirmwareByInstallOrder(firmwares []*model.Firmware) {
-	sort.Slice(firmwares, func(i, j int) bool {
-		slugi := strings.ToLower(firmwares[i].Component)
-		slugj := strings.ToLower(firmwares[j].Component)
-		return model.FirmwareInstallOrder[slugi] < model.FirmwareInstallOrder[slugj]
-	})
 }
 
 // statusEmitter implements the statemachine.Publisher interface

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -10,65 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_sortFirmwareByInstallOrde(t *testing.T) {
-	have := []*model.Firmware{
-		{
-			Version:   "DL6R",
-			URL:       "https://downloads.dell.com/FOLDER06303849M/1/Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
-			FileName:  "Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
-			Models:    []string{"r6515"},
-			Checksum:  "4189d3cb123a781d09a4f568bb686b23c6d8e6b82038eba8222b91c380a25281",
-			Component: "drive",
-		},
-		{
-			Version:   "2.6.6",
-			URL:       "https://dl.dell.com/FOLDER08105057M/1/BIOS_C4FT0_WN64_2.6.6.EXE",
-			FileName:  "BIOS_C4FT0_WN64_2.6.6.EXE",
-			Models:    []string{"r6515"},
-			Checksum:  "1ddcb3c3d0fc5925ef03a3dde768e9e245c579039dd958fc0f3a9c6368b6c5f4",
-			Component: "bios",
-		},
-		{
-			Version:   "20.5.13",
-			URL:       "https://dl.dell.com/FOLDER08105057M/1/Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
-			FileName:  "Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
-			Models:    []string{"r6515"},
-			Checksum:  "b445417d7869bdbdffe7bad69ce32dc19fa29adc61f8e82a324545cabb53f30a",
-			Component: "nic",
-		},
-	}
-
-	expected := []*model.Firmware{
-		{
-			Version:   "2.6.6",
-			URL:       "https://dl.dell.com/FOLDER08105057M/1/BIOS_C4FT0_WN64_2.6.6.EXE",
-			FileName:  "BIOS_C4FT0_WN64_2.6.6.EXE",
-			Models:    []string{"r6515"},
-			Checksum:  "1ddcb3c3d0fc5925ef03a3dde768e9e245c579039dd958fc0f3a9c6368b6c5f4",
-			Component: "bios",
-		},
-		{
-			Version:   "DL6R",
-			URL:       "https://downloads.dell.com/FOLDER06303849M/1/Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
-			FileName:  "Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
-			Models:    []string{"r6515"},
-			Checksum:  "4189d3cb123a781d09a4f568bb686b23c6d8e6b82038eba8222b91c380a25281",
-			Component: "drive",
-		},
-		{
-			Version:   "20.5.13",
-			URL:       "https://dl.dell.com/FOLDER08105057M/1/Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
-			FileName:  "Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
-			Models:    []string{"r6515"},
-			Checksum:  "b445417d7869bdbdffe7bad69ce32dc19fa29adc61f8e82a324545cabb53f30a",
-			Component: "nic",
-		},
-	}
-
-	sortFirmwareByInstallOrder(have)
-
-	assert.Equal(t, expected, have)
-}
 
 func Test_newTaskFromCondition(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
#### What does this PR do

  - outofband/action_handlers: introduce post install delay for BMC firmware, this fixes cases where the BMC is not yet ready to accept commands and results in failures for the next component firmware install.
  - worker: ensure firmware install is ordered, this was left out in a refactor