### PR TITLE
update dependencies for events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	go.hollow.sh/serverservice v0.15.4
-	go.hollow.sh/toolbox v0.6.1-0.20230629125041-f32670307308
+	go.hollow.sh/toolbox v0.6.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0
 	go.opentelemetry.io/otel v1.16.0
 	go.opentelemetry.io/otel/trace v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -820,12 +820,8 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230714054223-725e651bac57 h1:UPeJ7QUEpcVdJDcQa+/rGwaN9weJ6Juo9UBBWd1V864=
-github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230714054223-725e651bac57/go.mod h1:a3Ra0ce/LV3wAj7AHuphlHNTx5Sg67iQqtLGr1zoqio=
 github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230714085452-c13e347595e3 h1:+rxq+tlQzFHhK99oLahz+eSqhL1r+Y7OrjIOK8x0j6c=
 github.com/bmc-toolbox/bmclib/v2 v2.0.1-0.20230714085452-c13e347595e3/go.mod h1:a3Ra0ce/LV3wAj7AHuphlHNTx5Sg67iQqtLGr1zoqio=
-github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d h1:cQ30Wa8mhLzK1TSOG+g3FlneIsXtFgun61mmPwVPmD0=
-github.com/bmc-toolbox/common v0.0.0-20230220061748-93ff001f4a1d/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bmc-toolbox/common v0.0.0-20230717085817-bf797049f697 h1:7+PZslRhfmG04JD+/og6ImknU71dmQe60tC+mKl39W4=
 github.com/bmc-toolbox/common v0.0.0-20230717085817-bf797049f697/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
@@ -2296,8 +2292,8 @@ go.etcd.io/etcd/raft/v3 v3.5.0/go.mod h1:UFOHSIvO/nKwd4lhkwabrTD3cqW5yVyYYf/KlD0
 go.etcd.io/etcd/server/v3 v3.5.0/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
 go.hollow.sh/serverservice v0.15.4 h1:3yMep8c9aldHsrtU6BDTUH5oZ7a0LCamMOa6tflfhlw=
 go.hollow.sh/serverservice v0.15.4/go.mod h1:r/AmqMYmk935AuVEmCNXWT5+PoeCtTK+ScBv7ZAeD9g=
-go.hollow.sh/toolbox v0.6.1-0.20230629125041-f32670307308 h1:HLnKsGwkKkmKFNcvWIhGzLwLBkK1UHk0fgo7Q0Z5gBM=
-go.hollow.sh/toolbox v0.6.1-0.20230629125041-f32670307308/go.mod h1:nl+5RDDyYY/+wukOUzHHX2mOyWKRjlTOXUcGxny+tns=
+go.hollow.sh/toolbox v0.6.1 h1:3E6JofImSCe63XayczbGfDxIXUjmBziMBBmbwook8WA=
+go.hollow.sh/toolbox v0.6.1/go.mod h1:nl+5RDDyYY/+wukOUzHHX2mOyWKRjlTOXUcGxny+tns=
 go.infratographer.com/x v0.0.15 h1:swN19UZt7OR192ZKeNIyPUGoC9DWbwluT5kvZ9/Yqek=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=


### PR DESCRIPTION
#### What does this PR do
pulls in `hollow-toolbox/events` at 0.6.1 so we can correctly detect NATS timeout errors.
