### PR TITLE
Make installing the current firmware version a no-op

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 		"-X $(LDFLAG_LOCATION).GitCommit=$(GIT_COMMIT) \
          -X $(LDFLAG_LOCATION).GitBranch=$(GIT_BRANCH) \
          -X $(LDFLAG_LOCATION).GitSummary=$(GIT_SUMMARY) \
-         -X $(LDFLAG_LOCATION).Version=$(VERSION) \
+         -X $(LDFLAG_LOCATION).AppVersion=$(VERSION) \
          -X $(LDFLAG_LOCATION).BuildDate=$(BUILD_DATE)"
 
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 		"-X $(LDFLAG_LOCATION).GitCommit=$(GIT_COMMIT) \
          -X $(LDFLAG_LOCATION).GitBranch=$(GIT_BRANCH) \
          -X $(LDFLAG_LOCATION).GitSummary=$(GIT_SUMMARY) \
-         -X $(LDFLAG_LOCATION).Version=$(VERSION) \
+         -X $(LDFLAG_LOCATION).AppVersion=$(VERSION) \
          -X $(LDFLAG_LOCATION).BuildDate=$(BUILD_DATE)"
 
 

--- a/internal/outofband/actions.go
+++ b/internal/outofband/actions.go
@@ -188,7 +188,7 @@ func transitionRules() []sw.TransitionRule {
 			PostTransition:   handler.PublishStatus,
 			Documentation: sw.TransitionRuleDoc{
 				Name:        "Check installed firmware",
-				Description: "Check firmware installed on component - if its equal - returns error, unless Task.Parameters.Force=true.",
+				Description: "Check firmware installed on component",
 			},
 		},
 		{

--- a/internal/statemachine/task.go
+++ b/internal/statemachine/task.go
@@ -104,9 +104,6 @@ type TaskTransitioner interface {
 	// Plan creates a set of task actions to be executed.
 	Plan(task sw.StateSwitch, args sw.TransitionArgs) error
 
-	// ValidatePlan is called before invoking Run.
-	ValidatePlan(task sw.StateSwitch, args sw.TransitionArgs) (bool, error)
-
 	// Run executes the task actions.
 	Run(task sw.StateSwitch, args sw.TransitionArgs) error
 
@@ -194,7 +191,7 @@ func NewTaskStateMachine(handler TaskTransitioner) (*TaskStateMachine, error) {
 		TransitionType:   TransitionTypeRun,
 		SourceStates:     sw.States{model.StateActive},
 		DestinationState: model.StateSucceeded,
-		Condition:        handler.ValidatePlan,
+		Condition:        nil,
 		Transition:       handler.Run,
 		PostTransition:   handler.PublishStatus,
 		Documentation: sw.TransitionRuleDoc{

--- a/internal/worker/task_handler_test.go
+++ b/internal/worker/task_handler_test.go
@@ -3,8 +3,13 @@ package worker
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/metal-toolbox/flasher/internal/model"
+	sm "github.com/metal-toolbox/flasher/internal/statemachine"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.hollow.sh/toolbox/events/registry"
 )
 
 func Test_sortFirmwareByInstallOrde(t *testing.T) {
@@ -65,4 +70,69 @@ func Test_sortFirmwareByInstallOrde(t *testing.T) {
 	sortFirmwareByInstallOrder(have)
 
 	assert.Equal(t, expected, have)
+}
+
+func TestRemoveFirmwareAlreadyAtDesiredVersion(t *testing.T) {
+	t.Parallel()
+	fwSet := []*model.Firmware{
+		{
+			Version:   "2.6.6",
+			URL:       "https://dl.dell.com/FOLDER08105057M/1/BIOS_C4FT0_WN64_2.6.6.EXE",
+			FileName:  "BIOS_C4FT0_WN64_2.6.6.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "1ddcb3c3d0fc5925ef03a3dde768e9e245c579039dd958fc0f3a9c6368b6c5f4",
+			Component: "bios",
+		},
+		{
+			Version:   "DL6R",
+			URL:       "https://downloads.dell.com/FOLDER06303849M/1/Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
+			FileName:  "Serial-ATA_Firmware_Y1P10_WN32_DL6R_A00.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "4189d3cb123a781d09a4f568bb686b23c6d8e6b82038eba8222b91c380a25281",
+			Component: "drive",
+		},
+		{
+			Version:   "20.5.13",
+			URL:       "https://dl.dell.com/FOLDER08105057M/1/Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
+			FileName:  "Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "b445417d7869bdbdffe7bad69ce32dc19fa29adc61f8e82a324545cabb53f30a",
+			Component: "nic",
+		},
+	}
+	serverID := uuid.MustParse("fa125199-e9dd-47d4-8667-ce1d26f58c4a")
+	ctx := &sm.HandlerContext{
+		Logger: logrus.NewEntry(logrus.New()),
+		Asset: &model.Asset{
+			ID: serverID,
+			Components: model.Components{
+				{
+					Slug:              "BiOs",
+					FirmwareInstalled: "2.6.6",
+				},
+				{
+					Slug:              "nic",
+					FirmwareInstalled: "some-different-version",
+				},
+			},
+		},
+		Task: &model.Task{
+			ID: serverID, // it just needs to be a UUID
+		},
+		WorkerID: registry.GetID("test-app"),
+	}
+	expected := []*model.Firmware{
+		{
+			Version:   "20.5.13",
+			URL:       "https://dl.dell.com/FOLDER08105057M/1/Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
+			FileName:  "Network_Firmware_NVXX9_WN64_20.5.13_A00.EXE",
+			Models:    []string{"r6515"},
+			Checksum:  "b445417d7869bdbdffe7bad69ce32dc19fa29adc61f8e82a324545cabb53f30a",
+			Component: "nic",
+		},
+	}
+
+	got := removeFirmwareAlreadyAtDesiredVersion(ctx, fwSet)
+	require.Equal(t, 1, len(got))
+	require.Equal(t, expected[0], got[0])
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -401,8 +401,8 @@ func (o *Worker) runTaskWithMonitor(ctx context.Context, task *model.Task, asset
 		FacilityCode: o.facilityCode,
 		Logger: l.WithFields(
 			logrus.Fields{
-				"workerID":    o.id,
-				"conditionID": task.ID,
+				"workerID":    o.id.String(),
+				"conditionID": task.ID.String(),
 				"assetID":     asset.ID.String(),
 				"bmc":         asset.BmcAddress.String(),
 			},

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/metal-toolbox/flasher/internal/metrics"
 	"github.com/metal-toolbox/flasher/internal/model"
 	"github.com/metal-toolbox/flasher/internal/store"
+	"github.com/metal-toolbox/flasher/internal/version"
 	"github.com/nats-io/nats.go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -116,8 +117,12 @@ func (o *Worker) Run(ctx context.Context) {
 
 	o.startWorkerLivenessCheckin(ctx)
 
+	v := version.Current()
 	o.logger.WithFields(
 		logrus.Fields{
+			"version":         v.AppVersion,
+			"commit":          v.GitCommit,
+			"branch":          v.GitBranch,
 			"replica-count":   o.replicaCount,
 			"concurrency":     o.concurrency,
 			"dry-run":         o.dryrun,


### PR DESCRIPTION
#### What does this PR do
When Flasher is given a set of firmware, if any individual installed firmware version is equal to what is specified, the task fails with a suggestion to re-run it with `--force`. This is cumbersome in the case of modifying a single firmware in the set and then attempting to re-apply the set to a server, and instead of upgrading a single firmware, the entire set must be force-installed.

This PR changes that behavior be removing any firmware that is already at the desired level from the planned install actions. Thus any firmware already at the desired level will remain so and only the changed firmware will be installed.
