### PR TITLE
go: update bmclib for openbmc support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20190729070250-5ae5475bae5e
-	github.com/bmc-toolbox/bmclib/v2 v2.1.1-0.20231129094547-0df7b754427e
+	github.com/bmc-toolbox/bmclib/v2 v2.1.1-0.20231130133815-17b3809a2d4a
 	github.com/bmc-toolbox/common v0.0.0-20230717121556-5eb9915a8a5a
 	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmc-toolbox/bmclib/v2 v2.1.1-0.20231129094547-0df7b754427e h1:RvAD9NZt1tH6xv66/iAi1172NdEVDmlphH4ehKXta6A=
 github.com/bmc-toolbox/bmclib/v2 v2.1.1-0.20231129094547-0df7b754427e/go.mod h1:gFF4iD468hbW1JUdJJx3mbhNGzoLsG47epbMa++grp8=
+github.com/bmc-toolbox/bmclib/v2 v2.1.1-0.20231130133815-17b3809a2d4a h1:e4+Nr4yWq7lGyhZLoaK2506UehNXMPvoRWvyKyEdons=
+github.com/bmc-toolbox/bmclib/v2 v2.1.1-0.20231130133815-17b3809a2d4a/go.mod h1:gFF4iD468hbW1JUdJJx3mbhNGzoLsG47epbMa++grp8=
 github.com/bmc-toolbox/common v0.0.0-20230717121556-5eb9915a8a5a h1:SjtoU9dE3bYfYnPXODCunMztjoDgnE3DVJCPLBqwz6Q=
 github.com/bmc-toolbox/common v0.0.0-20230717121556-5eb9915a8a5a/go.mod h1:SY//n1PJjZfbFbmAsB6GvEKbc7UXz3d30s3kWxfJQ/c=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=


### PR DESCRIPTION
depends on https://github.com/bmc-toolbox/bmclib/pull/377
