### PR TITLE
Changes to compilation to support linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint: gen-mock
 
 ## Go test
 test: lint
-	CGO_ENABLED=0 go test -timeout 1m -v -covermode=atomic ./...
+	go test -timeout 1m -v -covermode=atomic ./...
 
 ## Generate mocks
 gen-mock:
@@ -29,39 +29,37 @@ gen-mock:
 
 ## build-osx
 build-osx:
-ifeq ($(GO_VERSION), 0)
+ifeq (${GO_VERSION}, 0)
 	$(error build requies go version 1.17.n or higher)
 endif
-	  go build -o flasher \
-	   -ldflags \
-		"-X $(LDFLAG_LOCATION).GitCommit=$(GIT_COMMIT) \
-         -X $(LDFLAG_LOCATION).GitBranch=$(GIT_BRANCH) \
-         -X $(LDFLAG_LOCATION).GitSummary=$(GIT_SUMMARY) \
-         -X $(LDFLAG_LOCATION).AppVersion=$(VERSION) \
-         -X $(LDFLAG_LOCATION).BuildDate=$(BUILD_DATE)"
-
+	CGO_ENABLED=0 go build -o flasher \
+		-ldflags \
+		"-X ${LDFLAG_LOCATION}.GitCommit=${GIT_COMMIT} \
+		 -X ${LDFLAG_LOCATION}.GitBranch=${GIT_BRANCH} \
+		 -X ${LDFLAG_LOCATION}.GitSummary=${GIT_SUMMARY} \
+		 -X ${LDFLAG_LOCATION}.AppVersion=${VERSION} \
+		 -X ${LDFLAG_LOCATION}.BuildDate=${BUILD_DATE}"
 
 ## Build linux bin
 build-linux:
-ifeq ($(GO_VERSION), 0)
+ifeq (${GO_VERSION}, 0)
 	$(error build requies go version 1.16.n or higher)
 endif
-	GOOS=linux GOARCH=amd64 go build -o flasher \
-	   -ldflags \
-		"-X $(LDFLAG_LOCATION).GitCommit=$(GIT_COMMIT) \
-         -X $(LDFLAG_LOCATION).GitBranch=$(GIT_BRANCH) \
-         -X $(LDFLAG_LOCATION).GitSummary=$(GIT_SUMMARY) \
-         -X $(LDFLAG_LOCATION).AppVersion=$(VERSION) \
-         -X $(LDFLAG_LOCATION).BuildDate=$(BUILD_DATE)"
-
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o flasher \
+		-ldflags \
+		"-X ${LDFLAG_LOCATION}.GitCommit=${GIT_COMMIT} \
+		 -X ${LDFLAG_LOCATION}.GitBranch=${GIT_BRANCH} \
+		 -X ${LDFLAG_LOCATION}.GitSummary=${GIT_SUMMARY} \
+		 -X ${LDFLAG_LOCATION}.AppVersion=${VERSION} \
+		 -X ${LDFLAG_LOCATION}.BuildDate=${BUILD_DATE}"
 
 ## build docker image and tag as ghcr.io/metal-toolbox/flasher:latest
 build-image: build-linux
 	@echo ">>>> NOTE: You may want to execute 'make build-image-nocache' depending on the Docker stages changed"
-	docker build --rm=true -f Dockerfile -t ${DOCKER_IMAGE}:latest  . \
-							 --label org.label-schema.schema-version=1.0 \
-							 --label org.label-schema.vcs-ref=$(GIT_COMMIT_FULL) \
-							 --label org.label-schema.vcs-url=$(REPO)
+	docker build --rm=true -f Dockerfile -t ${DOCKER_IMAGE}:latest . \
+		--label org.label-schema.schema-version=1.0 \
+		--label org.label-schema.vcs-ref=${GIT_COMMIT_FULL} \
+		--label org.label-schema.vcs-url=${REPO}
 
 ## tag and push devel docker image to local registry
 push-image-devel: build-image
@@ -73,13 +71,10 @@ push-image-devel: build-image
 push-image:
 	docker push ${DOCKER_IMAGE}:latest
 
-
 ## generate statemachine graphs and docs
 gen-docs:
-	go build -o flasher
+	CGO_ENABLED=0 go build -o flasher
 	./docs/statemachine/generate.sh
-
-
 
 # https://gist.github.com/prwhite/8168133
 # COLORS
@@ -87,7 +82,6 @@ GREEN  := $(shell tput -Txterm setaf 2)
 YELLOW := $(shell tput -Txterm setaf 3)
 WHITE  := $(shell tput -Txterm setaf 7)
 RESET  := $(shell tput -Txterm sgr0)
-
 
 TARGET_MAX_CHAR_NUM=20
 ## Show help
@@ -102,7 +96,7 @@ help:
 		if (helpMessage) { \
 			helpCommand = substr($$1, 0, index($$1, ":")-1); \
 			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+			printf "  ${YELLOW}%-${TARGET_MAX_CHAR_NUM}s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
 		} \
 	} \
-	{ lastLine = $$0 }' $(MAKEFILE_LIST)
+	{ lastLine = $$0 }' ${MAKEFILE_LIST}


### PR DESCRIPTION
Why CGO_ENABLED=0 to support linux:

> CGO_ENABLED tells Go to interoperate with C stdlibs. Its for xcompile. So it is dynamically linking the stdlibs when its started. So when we turn it off with CGO_ENABLED=0  we statically link the binary.
> Alpine is very lightweight, and don't have any stdlibs at all. They are expecting a fully functional binary. So when our containers (with dynamic linked) try to run the binary, they attempt to load in the shared libs.
>The problem is that on MacOS, this is by default turned off. On Linux it is on by default. So we need to turn it off.

Thats why you would get errors like this:
`exec /usr/sbin/flasher: no such file or directory`
Its not that the binary is missing, but that linux failed to find the shared libs it needed.

Also doing some cleanup of the makefile