### PR TITLE
Don't removeAll current firmware directory

### DIFF
--- a/internal/outofband/action_handlers.go
+++ b/internal/outofband/action_handlers.go
@@ -330,7 +330,6 @@ func (h *handler) uploadFirmware(ctx context.Context) error {
 	}
 
 	defer fileHandle.Close()
-	defer os.RemoveAll(filepath.Dir(h.action.FirmwareTempFile))
 
 	if !h.task.Parameters.DryRun {
 		// initiate firmware upload
@@ -385,7 +384,6 @@ func (h *handler) uploadFirmwareInitiateInstall(ctx context.Context) error {
 	}
 
 	defer fileHandle.Close()
-	defer os.RemoveAll(filepath.Dir(h.action.FirmwareTempFile))
 
 	if !h.task.Parameters.DryRun {
 		// initiate firmware install


### PR DESCRIPTION
When running the flasher on a local file, its whole dir is emptied by RemoveAll.

This is to ensure cleanup of firmware download dir, but will also remove all files beside the firmware on local test.
We should handle this at another level.

This PR removes the RemoveAll on non-tmp directories, to be safe.